### PR TITLE
fix cloud run deploy

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -67,10 +67,10 @@ jobs:
 
       - name: 🐳 Set up Docker Buildx
         id: builder
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: 🗝️ Authenticate Docker to Google CLoud
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: gcr.io
           username: oauth2accesstoken
@@ -78,7 +78,7 @@ jobs:
 
       - name: 🏷️ Extract tags from GitHub
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: gcr.io/${{ secrets.PROJECT_ID }}/app
           tags: |
@@ -88,7 +88,7 @@ jobs:
             latest
 
       - name: 📦 Build and push image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           builder: ${{ steps.builder.outputs.name }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -99,13 +99,13 @@ jobs:
 
       - name: 🚀 Deploy to Cloud Run
         id: deploy
-        uses: google-github-actions/deploy-cloudrun@v0
+        uses: google-github-actions/deploy-cloudrun@v0.9.0
         with:
           service: printproxy
           image: gcr.io/${{ secrets.PROJECT_ID }}/app
           region: us-central1
           env_vars: "OPEN_QUAD_WORD=${{ secrets.OPEN_QUAD_WORD }}"
-          flags: |
+          flags: >
             --service-account=cloud-run-sa@${{ secrets.PROJECT_ID }}.iam.gserviceaccount.com
             --allow-unauthenticated
 
@@ -138,10 +138,10 @@ jobs:
 
       - name: 🐳 Set up Docker Buildx
         id: builder
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: 🗝️ Authenticate Docker to Google CLoud
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: gcr.io
           username: oauth2accesstoken
@@ -149,7 +149,7 @@ jobs:
 
       - name: 🏷️ Extract tags from GitHub
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: gcr.io/${{ secrets.PROJECT_ID }}/app
           tags: |
@@ -159,7 +159,7 @@ jobs:
             latest
 
       - name: 📦 Build and push image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           builder: ${{ steps.builder.outputs.name }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -170,13 +170,13 @@ jobs:
 
       - name: 🚀 Deploy to Cloud Run
         id: deploy
-        uses: google-github-actions/deploy-cloudrun@v0
+        uses: google-github-actions/deploy-cloudrun@v0.9.0
         with:
           service: printproxy
           image: gcr.io/${{ secrets.PROJECT_ID }}/app
           region: us-central1
           env_vars: "OPEN_QUAD_WORD=${{ secrets.OPEN_QUAD_WORD }}"
-          flags: |
+          flags: >
             --service-account=cloud-run-sa@${{ secrets.PROJECT_ID }}.iam.gserviceaccount.com
             --allow-unauthenticated
             --concurrency=80

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,13 @@
 {
   "cSpell.words": [
+    "accesstoken",
     "autodeploy",
+    "Buildx",
     "cloudfunctions",
+    "cloudrun",
     "entrypoint",
     "enviro",
+    "gserviceaccount",
     "printproxy",
     "promisify",
     "utahkoopserver"


### PR DESCRIPTION
I'm hoping this fixes the cloud run deploy in production. It fixed it in staging. I believe that the `flags` param should be space-separated rather than with new lines.

I'm waiting on the security exception to be applied to the dev gcp project so that I can test this.